### PR TITLE
Fix multicast traffic using the wrong interface

### DIFF
--- a/aes67.js
+++ b/aes67.js
@@ -145,6 +145,9 @@ if(program.mcast){
 
 logger('Selected '+aes67Multicast+' as RTP multicast address.');
 
+// Add interface to multicast membership (otherwise the OS randomly selects an interface for the multicast traffic)
+client.addMembership(aes67Multicast, addr);
+
 //AES67 params (hardcoded)
 const samplerate = 48000;
 const ptime = 1;


### PR DESCRIPTION
On my computer the RTP multicast packets were using the wrong interface (checked using wireshark)

As there is nothing to tell the socket what interface to transmit the packet on
```js
client.send(rtpBuffer, 5004, aes67Multicast);	
```

The solution is as simple as making the network interface join the multicast group
```js
client.addMembership(aes67Multicast, addr);
```

This has been checked in wireshark using a Symetrix Radius 12x8 EX